### PR TITLE
Fix to issue #1. Set zoom to empty string (blank) if zoom argument is undefined

### DIFF
--- a/src/L.Control.ZoomDisplay.js
+++ b/src/L.Control.ZoomDisplay.js
@@ -24,6 +24,7 @@ L.Control.ZoomDisplay = L.Control.extend({
     },
 
     updateMapZoom: function (zoom) {
+        if(typeof(zoom) === "undefined"){zoom = ""}
         this._container.innerHTML = zoom;
     }
 });


### PR DESCRIPTION
This fixed the issue I was having so maybe others will benefit as well.
